### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/server/app-sam.yaml
+++ b/server/app-sam.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: "stations.list"
-      Runtime: "nodejs4.3"
+      Runtime: "nodejs10.x"
       CodeUri: "api/"
       Policies: "AWSLambdaVPCAccessExecutionRole"
       VpcConfig:
@@ -46,7 +46,7 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: "stations.setup"
-      Runtime: "nodejs4.3"
+      Runtime: "nodejs10.x"
       CodeUri: "api/"
       Policies: "AmazonDynamoDBFullAccess"
       Timeout: 10
@@ -68,7 +68,7 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: "index.handler"
-      Runtime: "nodejs4.3"
+      Runtime: "nodejs10.x"
       CodeUri: "stream/"
       Policies: "AWSLambdaVPCAccessExecutionRole"
       VpcConfig:


### PR DESCRIPTION
CloudFormation templates in elasticache-geospatial-public-bikes have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.